### PR TITLE
Use ubuntu-slim GitHub runner

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   ruff:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
 
     env:
       RUFF_OUTPUT_FORMAT: github
@@ -24,7 +24,7 @@ jobs:
         run: uv run ruff check .
 
   mypy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
 
     strategy:
       matrix:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   merge:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     if: github.actor == 'dependabot[bot]' && github.repository == 'josh/lru-cache-python'
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
 
     steps:
       - uses: actions/checkout@v5
@@ -27,7 +27,7 @@ jobs:
           path: dist/*
 
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- migrate workflow jobs running on ubuntu-24.04 to the ubuntu-slim runner
- apply the runner update across merge, lint, test, and release workflows

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923766ce1e48326a81cc6f1679e867b)