### PR TITLE
Pin actions to full-length commit sha

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,9 @@ jobs:
       RUFF_OUTPUT_FORMAT: github
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
 
       - name: Install dependencies
         run: uv sync
@@ -34,9 +34,9 @@ jobs:
       UV_RESOLUTION: ${{ matrix.uv_resolution }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
 
       - name: Enable auto-merge
         if: steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-slim
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
 
       - name: Install dependencies
         run: uv sync
@@ -24,7 +24,7 @@ jobs:
         run: |
           uv run python -m build
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: dist
           path: dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-slim
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
 
       - name: Install dependencies
         run: uv sync
@@ -21,7 +21,7 @@ jobs:
         run: |
           uv run python -m build
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: dist
           path: dist/*
@@ -46,9 +46,9 @@ jobs:
       UV_RESOLUTION: ${{ matrix.uv_resolution }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # v7.1.5
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary
- pin GitHub Actions in workflow files to full-length commit shas with version comments

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939c553160883269cec0e1cad09ec98)