### PR TITLE
Pin actions to full-length commit sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           name: dist
           path: dist/*
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           files: |
             lru_cache.py


### PR DESCRIPTION
## Summary
- pin softprops/action-gh-release to the published commit SHA with version comment

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939d3af99fc8326b9ee1dd1855969eb)